### PR TITLE
Michelle component styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,7 @@
 import './App.scss';
 import "./fonts/lulo-clean-one.ttf";
-import Navigation from '../src/components/navigation';
 import Home from '../src/pages/Home';
-import Checkout from '../src/pages/Checkout';
+import Order from './pages/Order';
 import Catering from '../src/pages/Catering';
 import Reservations from '../src/pages/Reservations';
 import About from '../src/pages/About';
@@ -24,7 +23,7 @@ function App() {
                          <Route exact path="/reservations" element={<Reservations />}/>
                          <Route exact path="/catering" element={<Catering />} />
                          <Route exact path="/about"  element={<About />}/>
-                         <Route exact path="/checkout" element={<Checkout />} />
+                         <Route exact path="/order" element={<Order />} />
                     </Routes>
                </Router>
           <Footer/>

--- a/src/App.scss
+++ b/src/App.scss
@@ -30,7 +30,7 @@
 
 .menuHero {
     width: 100%;
-    height: 700px;
+    height: 500px;
     background-image: url(assets/cafe-room.png);
     background-repeat: no-repeat;
     background-size: cover;
@@ -103,12 +103,105 @@
 
 .reserveHero {
     width: auto;
-    height: 1000px;
+    height: 700px;
     background-image: url(assets/cafe-entrance.png);
     background-repeat: no-repeat;
     background-size: cover;
 }
 
+//CATERING
+#cateringHero {
+     width: auto;
+     height: 500px;
+     background-image: url(assets/bowls.jpg);
+     background-repeat: no-repeat;
+     background-size: cover;
+}
+#cateringInfo {
+     margin: 0;
+     font-size: 25px;
+     text-indent: 2rem;
+     text-justify: auto;
+     padding: 40px;
+}
+
+.cateringOptions {
+     font-family: "Lulo Clean Bold", sans-serif;
+     font-size: 25px;
+     padding-bottom: 40px;
+}
+#breakfastCatering, #lunchCatering {
+margin-bottom: 50px;
+}
+@media only screen and (min-width: 800px) {
+     .mealOptions{
+          display: flex;
+     }
+     .tierOne, .tierTwo{
+          width: 50%;
+     }
+     .enhancementOption {
+          display: inline-block;
+          vertical-align: top;
+          width: 50%;
+     
+     }
+     .cateringDescription {
+          margin-bottom: 20px;
+     }
+     .cateringPrice {
+          position: absolute;
+          margin: auto;
+          bottom: 20px;
+     }
+}
+.tierOne {
+     position: relative;
+     background-color:#D9981E;
+     font-family: 'Avenir LT Std', sans-serif;
+     font-size: 20px;
+     border-radius: 10px;
+     padding: 30px;
+     margin: 10px;
+}
+
+.tierTwo {
+     position: relative;
+     background-color:#F28B0C;
+     font-family: 'Avenir LT Std', sans-serif;
+     font-size: 20px;
+     border-radius: 10px;
+     padding: 30px;
+     margin: 10px;
+}
+.addOns{
+     position: relative;
+     background-color:#BF7960;
+     font-family: 'Avenir LT Std', sans-serif;
+     font-size: 20px;
+     border-radius: 10px;
+     padding: 30px;
+     margin-top: 10px;
+
+}
+
+
+
+@media only screen and (max-width: 799px) {
+     .mealOptions {
+          display:block;
+          flex-wrap: none;
+     }
+   }
+
+//ORDER
+.orderHero {
+     width: auto;
+     height: 500px;
+     background-image: url(assets/brunch-board.jpg);
+     background-repeat: no-repeat;
+     background-size: cover;
+}
 
 
 // FOOTER

--- a/src/App.scss
+++ b/src/App.scss
@@ -204,6 +204,19 @@ margin-bottom: 50px;
      background-size: cover;
      background-attachment: fixed;
 }
+#orderIntro {
+     margin: 0;
+     font-size: 25px;
+     text-indent: 2rem;
+     text-justify: auto;
+     padding: 40px;
+}
+.orderCategory {
+     font-family: "Lulo Clean Bold", sans-serif;
+     font-size: 25px;
+     padding-top: 20px;
+     padding-bottom: 20px;
+ }
 
 //ABOUT US
 .aboutUsHero {

--- a/src/App.scss
+++ b/src/App.scss
@@ -116,6 +116,7 @@
      background-image: url(assets/bowls.jpg);
      background-repeat: no-repeat;
      background-size: cover;
+     background-attachment: fixed;
 }
 #cateringInfo {
      margin: 0;
@@ -133,28 +134,7 @@
 #breakfastCatering, #lunchCatering {
 margin-bottom: 50px;
 }
-@media only screen and (min-width: 800px) {
-     .mealOptions{
-          display: flex;
-     }
-     .tierOne, .tierTwo{
-          width: 50%;
-     }
-     .enhancementOption {
-          display: inline-block;
-          vertical-align: top;
-          width: 50%;
-     
-     }
-     .cateringDescription {
-          margin-bottom: 20px;
-     }
-     .cateringPrice {
-          position: absolute;
-          margin: auto;
-          bottom: 20px;
-     }
-}
+
 .tierOne {
      position: relative;
      background-color:#D9981E;
@@ -185,7 +165,28 @@ margin-bottom: 50px;
 
 }
 
-
+@media only screen and (min-width: 800px) {
+     .mealOptions{
+          display: flex;
+     }
+     .tierOne, .tierTwo{
+          width: 50%;
+     }
+     .enhancementOption {
+          display: inline-block;
+          vertical-align: top;
+          width: 50%;
+     
+     }
+     .cateringDescription {
+          margin-bottom: 20px;
+     }
+     .cateringPrice {
+          position: absolute;
+          margin: auto;
+          bottom: 20px;
+     }
+}
 
 @media only screen and (max-width: 799px) {
      .mealOptions {
@@ -201,8 +202,26 @@ margin-bottom: 50px;
      background-image: url(assets/brunch-board.jpg);
      background-repeat: no-repeat;
      background-size: cover;
+     background-attachment: fixed;
 }
 
+//ABOUT US
+.aboutUsHero {
+     width: auto;
+     height: 500px;
+     background-image: url(assets/Mimosa-on-a-Brunch-Table-scaled.jpg);
+     background-repeat: no-repeat;
+     background-size: cover;
+     background-attachment: fixed;
+}
+#aboutUsIntro {
+     margin: 0;
+     font-size: 25px;
+     text-indent: 2rem;
+     text-justify: auto;
+     padding: 40px;
+
+}
 
 // FOOTER
 .footerColor {

--- a/src/App.scss
+++ b/src/App.scss
@@ -220,9 +220,13 @@ margin-bottom: 50px;
      text-indent: 2rem;
      text-justify: auto;
      padding: 40px;
+}
+.teamMember{
+     font-family: "Lulo Clean Bold", sans-serif;
+     font-size: 25px;
+     padding-bottom: 40px;
 
 }
-
 // FOOTER
 .footerColor {
     background-color: $footer-bkg-color;

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -21,7 +21,7 @@ class Footer extends React.Component {
                          <NavLink href="/">MENU</NavLink>
                          <NavLink href="/catering">CATERING</NavLink>
                          <NavLink href="/about">ABOUT</NavLink>
-                         <NavLink href="/checkout">CHECKOUT</NavLink>
+                         <NavLink href="/order">ORDER</NavLink>
                     </Nav>
                     </div>
 

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -18,7 +18,7 @@ class Navigation extends React.Component {
                          <NavLink href="/about">ABOUT</NavLink>
                     </NavItem>
                     <NavItem>
-                         <NavLink href="/checkout">CHECKOUT</NavLink>
+                         <NavLink href="/order">ORDER</NavLink>
                     </NavItem>    
 
                     <Button variant="warning" className="reserveButton" href="/reservations">BOOK A RESERVATION</Button>           

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -6,10 +6,17 @@ class About extends React.Component {
      render() {
           return (<>
                     <div className="aboutUsHero"></div>
-                    <p id="aboutUsIntro" className="text-center justify-content-center"> Meet the passionate team behind <strong>Morning Snack.</strong>
+                    <p id="aboutUsIntro" className="text-center justify-content-center"> Meet the passionate team behind <strong>Morning Snack</strong>.
                     </p>
                     <h1 className="pageHeader text-center">MEET THE TEAM</h1>
-              <Container></Container>
+              <Container>
+                   <div>
+                        <h2 className="teamMember">Hunter</h2>
+                   </div>
+                   <div>
+                        <h2 className="teamMember">Michelle</h2>
+                   </div>
+              </Container>
           </>  
           )  
      }

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -1,11 +1,15 @@
 import React from 'react';
+import { Container } from 'react-bootstrap';
 
 class About extends React.Component {
 
      render() {
           return (<>
-              <h1>WELCOME</h1>
-              <p>This is morning snack's about us page</p>
+                    <div className="aboutUsHero"></div>
+                    <p id="aboutUsIntro" className="text-center justify-content-center"> Meet the passionate team behind <strong>Morning Snack.</strong>
+                    </p>
+                    <h1 className="pageHeader text-center">MEET THE TEAM</h1>
+              <Container></Container>
           </>  
           )  
      }

--- a/src/pages/Catering.js
+++ b/src/pages/Catering.js
@@ -1,46 +1,94 @@
 import React from 'react';
+import { Container } from 'react-bootstrap';
 
 class Catering extends React.Component {
 
      render() {
           return (
-              <div>
-                   <h1>Catering</h1>
-                   <p>We offer both breakfast and lunch catering options for your event.</p>
-                   <div id="breakfast-catering">
-                         <h3>Breakfast</h3>
-                         <h4>Tier 1 - Morning Pastries Package - $15 per person</h4>
-                         <p> An assortment of muffins, bagels, danishes, croissants, served with butter and a variety of jams. Coffee and water available for beverages</p>
-                         <h4>Tier 2 - American Breakfast Package - $25 per person</h4>
-                         <p>Scrambled Eggs, bacon, breakfast sausage, southwestern breakfast potatoes, and an assortment of pastries. Coffee, your choice of 2 types of juices, and water available for beverages</p>
-                         <h4>Add On- Omelette Station - $20 per person</h4>
-                         <p>A number of omelette chefs will be provided for the omelette station, varying based on event size. Below are the filling options.</p>
-                         <ul>
-                              <li>Proteins: Bacon, Pork Sausage, Turkey Sausage, Chicken, Vegan Sausage, Tofu</li>
-                              <li>Vegetables: Tomato, Onion, Mushroom, Jalapeno, Red & Green Bell Pepper, Spinach, Avocado, Green Onion</li>
-                              <li>Cheeses: Cheddar, Swiss, Mozzarella, Pepper Jack</li>
-                         </ul>
-                         <h4>Add On - Fruit $10 per person</h4>
-                         <p>An assortment of apples, pears, bananas, and oranges and a berry meledy</p>
-                   </div>
-                   <div id="lunch-catering">
-                         <h3>Lunch</h3>
-                         <h4>Tier 1 - Light Lunch Package - $20 per person</h4>
-                         <p> An assortment of sandwiches, 2 soups of your choice, and caesar salad. Iced Tea, Coke Products, and Water avaialble for beverages</p>
-                         <ul>
-                              <li>Sandwiches - Turkey & Swiss, Ham & Cheddar, Fresh Vegetables & Hummus</li>
-                              <li>Soups- Tomato Basil, Tortilla, French Onion, Seasonal</li>
-                         </ul>
-                         <h4>Tier 2 - Burger Package $30 per person</h4>
-                         <p>Beef or black bean patties, American Chees, Lettuce, Tomato, Onion, Pickles served on a brioche bung. Fries and caesar salad for sides. Iced Tea, Coke Products, and water available for beverages</p>
-                         <h4>Add On - Desserts - $15 per person</h4>
-                         <p>Choclate chip, oatmeal rasin, and snickerdoodle cookies, chocolate brownies</p>
-                         <h4>Add On - Fruit - $10 per person</h4>
-                              <p>An assortment of apples, pears, bananas, and oranges and a berry meledy</p>
-                   </div>
-                   <p id="catering-dietary">*Vegan and allergy accomodations available upon request</p>
-              </div>
-          )  
+               <div>
+                    <div id="cateringHero"></div>
+                    <p id="cateringInfo" className="text-center justify-content-center"><strong>Morning Snack</strong> offers both
+                         breakfast and lunch catering options for your event's needs. Below are a variety of options to make your event
+                         one to remember. Please alert us of any dietery restrictions. We are happy to make accomodations for all your guests.
+                    </p>
+                    <h1 className="pageHeader text-center">CATERING MENU</h1>
+                    <Container id="breakfastCatering">
+                         <h3 className="cateringOptions">Breakfast</h3>
+                         <div className="mealOptions">
+                              <div className="tierOne">
+                                   <p>MORNING PASTRIES PACKAGE</p>
+                                   <p className="cateringDescription"> An assortment of muffins, bagels, danishes, croissants, served with butter and a variety of jams. Coffee and water available for beverages</p>
+                                   <p className="cateringPrice">$15 PP</p>
+                              </div>
+                              <div className="tierTwo">
+                                   <p>AMERICAN BREAKFAST PACKAGE</p>
+                                   <p className="cateringDescription">Scrambled Eggs, bacon, breakfast sausage, southwestern breakfast potatoes, and an assortment of pastries. Coffee, your choice of 2 types of juices, and water available for beverages</p>
+                                   <p className="cateringPrice">$25 PP</p>
+                              </div>
+                         </div>
+
+                         <div className="addOns">
+                              <h4>ENHANCEMENTS</h4>
+                              <p>Evelate your breakfast by adding on one of the options below to your chosen breakfast package.</p>
+                              <div className="enhancementOption">
+                                   <p>OMELETTE STATION</p>
+                                   <p>A number of omelette chefs will be provided for the omelette station, varying based on event size. Below are the filling options.</p>
+                                   <ul className="cateringDescription">
+                                        <li>Proteins: Bacon, Pork Sausage, Turkey Sausage, Chicken, Vegan Sausage, Tofu</li>
+                                        <li>Vegetables: Tomato, Onion, Mushroom, Jalapeno, Red & Green Bell Pepper, Spinach, Avocado, Green Onion</li>
+                                        <li>Cheeses: Cheddar, Swiss, Mozzarella, Pepper Jack</li>
+                                   </ul>
+                                   <p className="cateringPrice">$20 PP</p>
+                              </div>
+                              <div className="enhancementOption">
+
+                                   <p>SMOOTHIE BOWLS</p>
+                                   <ul className="cateringDescription">
+                                        <li>Mixed Berry: Strawberry Blueberry blend topped with fresh raspberries, blueberries, blackberries, flax and chia seeds</li>
+                                        <li>Peanut Butter Chocolate Dream: Chocolate peanut butter and banana blend topped with coconut, chocolate nibs, sliced banana, and crushed peanuts </li>
+                                        <li>Tropical Vibes: Pineapple Mango blend topped with kiwi, mango, dates, and coconut</li>
+                                   </ul>
+                                   <p className="cateringPrice">$15 PP</p>
+                              </div>
+                         </div>
+                    </Container>
+                    <Container id="lunchCatering">
+                         <h3 className="cateringOptions">Lunch</h3>
+                         <div className="mealOptions">
+                              <div className="tierOne">
+                                   <p>LIGHT LUNCH PACKAGE</p>
+                                   <p> An assortment of sandwiches, 2 soups of your choice, and caesar salad. Iced Tea, Coke Products, and Water avaialble for beverages</p>
+                                   <ul className="cateringDescription">
+                                        <li>Sandwiches - Turkey & Swiss, Ham & Cheddar, Fresh Vegetables & Hummus</li>
+                                        <li>Soups- Tomato Basil, Tortilla, French Onion, Seasonal</li>
+                                   </ul>
+                                   <p className="cateringPrice">$20 PP</p>
+                              </div>
+                              <div className="tierTwo">
+                                   <h4> BURGERS AND SIDES PACKAGE</h4>
+                                   <p className="cateringDescription">Beef or black bean patties, American Chees, Lettuce, Tomato, Onion, Pickles served on a brioche bung. Fries and caesar salad for sides. Iced Tea, Coke Products, and water available for beverages</p>
+                                   <p className="cateringPrice">$30 PP</p>
+                              </div>
+                         </div>
+
+                         <div className="addOns">
+                              <h4>ENHANCEMENTS</h4>
+                              <p>Energize your guests' afternoon with one of the options below as an addition to your chosen lunch package.</p>
+                              <div className="enhancementOption">
+                                   <p>DESSERTS</p>
+                                   <p className="cateringDescription">Choclate chip, oatmeal rasin, and snickerdoodle cookies, chocolate brownies</p>
+                                   <p className="cateringPrice">$15 PP</p>
+                              </div>
+                              <div className="enhancementOption">
+                                   <p>FRUIT</p>
+                                   <p className="cateringDescription">An assortment of apples, pears, bananas, and oranges and a berry meledy</p>
+                                   <p className="cateringPrice">$10 PP</p>
+                              </div>
+
+                         </div>
+                    </Container>
+               </div>
+          )
      }
 }
 

--- a/src/pages/Checkout.js
+++ b/src/pages/Checkout.js
@@ -44,7 +44,7 @@ class Checkout extends React.Component {
                     { id: 5, name: "Mimosa", price: 7, quantity: 0 },
                     { id: 6, name: "Bloody Mary", price: 7, quantity: 0 }
                ],
-               total: 0          
+               total: 0
           }
      }
 
@@ -78,124 +78,127 @@ class Checkout extends React.Component {
           if (this.calculateSubtotal() === 0) {
                const total = 0;
                return total;
-          } else  {
+          } else {
                const subtotal = this.calculateSubtotal();
-               const tipPercentage = parseFloat((this.state.tipPercentage)/100);
+               const tipPercentage = parseFloat((this.state.tipPercentage) / 100);
                const tipAmount = subtotal * tipPercentage;
                const total = subtotal + tipAmount;
                return total;
           }
-        }
+     }
 
 
      render() {
           return (
-               <Container>
-                    <Form>
-                         <h3>Appetizers</h3>
-                         {this.state.appetizers.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
+               <div>
+                    <div className="orderHero"></div>
+                    <Container>
+                         <Form>
+                              <h3>Appetizers</h3>
+                              {this.state.appetizers.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "appetizers", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <h3>Soups & Salads</h3>
+                              {this.state.soupsAndSalads.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "appetizers", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <h3>Sandwiches</h3>
+                              {this.state.sandwiches.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "sandwiches", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <h3>Entrees</h3>
+                              {this.state.entrees.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "entrees", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <h3>Desserts</h3>
+                              {this.state.desserts.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "desserts", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <h3>Drinks</h3>
+                              {this.state.drinks.map((item) => (
+                                   <InputGroup className="mb-3" key={item.id}>
+                                        <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
+                                        <InputGroup.Text>{item.name}</InputGroup.Text>
+                                        <FormControl
+                                             type="number"
+                                             min="0"
+                                             aria-label=""
+                                             value={item.quantity}
+                                             onChange={(e) => this.handleQuantityChange(e, "drinks", item)}
+                                        />
+                                   </InputGroup>
+                              ))}
+                              <InputGroup className="mb-3">
+                                   <InputGroup.Text>Subtotal:</InputGroup.Text>
+                                   <InputGroup.Text>${this.calculateSubtotal().toFixed(2)}</InputGroup.Text>
+                              </InputGroup>
+                              <InputGroup className="mb-3">
+                                   <InputGroup.Text>Tip (%):</InputGroup.Text>
                                    <FormControl
                                         type="number"
                                         min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "appetizers", item)}
+                                        aria-label="Tip percentage"
+                                        value={this.state.tipPercentage || ''}
+                                        onChange={(e) => this.setState({ tipPercentage: e.target.value })}
                                    />
                               </InputGroup>
-                         ))}
-                         <h3>Soups & Salads</h3>
-                         {this.state.soupsAndSalads.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
-                                   <FormControl
-                                        type="number"
-                                        min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "appetizers", item)}
-                                   />
+                              <InputGroup className="mb-3">
+                                   <InputGroup.Text>Total:</InputGroup.Text>
+                                   <InputGroup.Text>${this.calculateTotal().toFixed(2)}</InputGroup.Text>
                               </InputGroup>
-                         ))}
-                         <h3>Sandwiches</h3>
-                         {this.state.sandwiches.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
-                                   <FormControl
-                                        type="number"
-                                        min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "sandwiches", item)}
-                                   />
-                              </InputGroup>
-                         ))}
-                         <h3>Entrees</h3>
-                         {this.state.entrees.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
-                                   <FormControl
-                                        type="number"
-                                        min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "entrees", item)}
-                                   />
-                              </InputGroup>
-                         ))}
-                         <h3>Desserts</h3>
-                         {this.state.desserts.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
-                                   <FormControl
-                                        type="number"
-                                        min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "desserts", item)}
-                                   />
-                              </InputGroup>
-                         ))}
-                         <h3>Drinks</h3>
-                         {this.state.drinks.map((item) => (
-                              <InputGroup className="mb-3" key={item.id}>
-                                   <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
-                                   <InputGroup.Text>{item.name}</InputGroup.Text>
-                                   <FormControl
-                                        type="number"
-                                        min="0"
-                                        aria-label=""
-                                        value={item.quantity}
-                                        onChange={(e) => this.handleQuantityChange(e, "drinks", item)}
-                                   />
-                              </InputGroup>
-                         ))}
-                         <InputGroup className="mb-3">
-                              <InputGroup.Text>Subtotal:</InputGroup.Text>
-                              <InputGroup.Text>${this.calculateSubtotal().toFixed(2)}</InputGroup.Text>
-                         </InputGroup>
-                         <InputGroup className="mb-3">
-                              <InputGroup.Text>Tip (%):</InputGroup.Text>
-                              <FormControl
-                                   type="number"
-                                   min="0"
-                                   aria-label="Tip percentage"
-                                   value={this.state.tipPercentage || ''}
-                                   onChange={(e) => this.setState({ tipPercentage: e.target.value })}
-                              />
-                         </InputGroup>
-                         <InputGroup className="mb-3">
-                              <InputGroup.Text>Total:</InputGroup.Text>
-                              <InputGroup.Text>${this.calculateTotal().toFixed(2)}</InputGroup.Text>
-                         </InputGroup>
-                    </Form>
-               </Container>
+                         </Form>
+                    </Container>
+               </div>
           )
      }
 }

--- a/src/pages/Checkout.js
+++ b/src/pages/Checkout.js
@@ -92,6 +92,11 @@ class Checkout extends React.Component {
           return (
                <div>
                     <div className="orderHero"></div>
+                    <p id="cateringInfo" className="text-center justify-content-center">Not in the mood to dine in?
+                    <strong>Morning Snack</strong> offers take out so you can take your brunch wherever you'd like!
+                    When your order is ready, see the host stand to pick it up.
+                    </p>
+                    <h1 className="pageHeader text-center">ORDER NOW</h1>
                     <Container>
                          <Form>
                               <h3>Appetizers</h3>

--- a/src/pages/Order.js
+++ b/src/pages/Order.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Container, Form, InputGroup, FormControl } from 'react-bootstrap';
 
-class Checkout extends React.Component {
+class Order extends React.Component {
      constructor(props) {
           super(props);
           this.state = {
@@ -92,8 +92,8 @@ class Checkout extends React.Component {
           return (
                <div>
                     <div className="orderHero"></div>
-                    <p id="cateringInfo" className="text-center justify-content-center">Not in the mood to dine in?
-                    <strong>Morning Snack</strong> offers take out so you can take your brunch wherever you'd like!
+                    <p id="cateringInfo" className="text-center justify-content-center">Not in the mood to dine in? 
+                    <strong> Morning Snack</strong> offers take out so you can take your brunch wherever you'd like!
                     When your order is ready, see the host stand to pick it up.
                     </p>
                     <h1 className="pageHeader text-center">ORDER NOW</h1>
@@ -208,4 +208,4 @@ class Checkout extends React.Component {
      }
 }
 
-export default Checkout;
+export default Order;

--- a/src/pages/Order.js
+++ b/src/pages/Order.js
@@ -92,14 +92,14 @@ class Order extends React.Component {
           return (
                <div>
                     <div className="orderHero"></div>
-                    <p id="cateringInfo" className="text-center justify-content-center">Not in the mood to dine in? 
+                    <p id="orderIntro" className="text-center justify-content-center">Not in the mood to dine in? 
                     <strong> Morning Snack</strong> offers take out so you can take your brunch wherever you'd like!
                     When your order is ready, see the host stand to pick it up.
                     </p>
                     <h1 className="pageHeader text-center">ORDER NOW</h1>
                     <Container>
                          <Form>
-                              <h3>Appetizers</h3>
+                              <h3 className="orderCategory">Appetizers</h3>
                               {this.state.appetizers.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
@@ -113,7 +113,7 @@ class Order extends React.Component {
                                         />
                                    </InputGroup>
                               ))}
-                              <h3>Soups & Salads</h3>
+                              <h3 className="orderCategory">Soups & Salads</h3>
                               {this.state.soupsAndSalads.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
@@ -127,7 +127,7 @@ class Order extends React.Component {
                                         />
                                    </InputGroup>
                               ))}
-                              <h3>Sandwiches</h3>
+                              <h3 className="orderCategory">Sandwiches</h3>
                               {this.state.sandwiches.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
@@ -141,7 +141,7 @@ class Order extends React.Component {
                                         />
                                    </InputGroup>
                               ))}
-                              <h3>Entrees</h3>
+                              <h3 className="orderCategory">Entrees</h3>
                               {this.state.entrees.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
@@ -155,7 +155,7 @@ class Order extends React.Component {
                                         />
                                    </InputGroup>
                               ))}
-                              <h3>Desserts</h3>
+                              <h3 className="orderCategory">Desserts</h3>
                               {this.state.desserts.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>
@@ -169,7 +169,7 @@ class Order extends React.Component {
                                         />
                                    </InputGroup>
                               ))}
-                              <h3>Drinks</h3>
+                              <h3 className="orderCategory">Drinks</h3>
                               {this.state.drinks.map((item) => (
                                    <InputGroup className="mb-3" key={item.id}>
                                         <InputGroup.Text>${item.price.toFixed(2)}</InputGroup.Text>


### PR DESCRIPTION
Renamed Checkout to Order, sounds nicer IMO but can change it back if you disagree. Made sure to change component name and routing for navigation & footer as well.
Added styling to catering, checkout, and starter styling to About us for when we get to it.
Added heroes to remaining pages, made them fixed so as you scroll, they stay and the content scrolls over it. I didn't do this to the homepage/menu since there's a comment for an image gallery to be added.

For the Catering page, I made it similar to how the menu was done to try and keep it fluid looking. If you make any drastic changes to the menu, let me know! Also, for catering I added @media only tags for min & max width screens so the page doesn't get messed up because of how I styled the menus. In width under 800px, they are in a single column where in width 800 & over, the two main packages are side by side menus. We'll need to do this for some of the other components such as Navigation, maybe the menu page, and the footer. The content on the other pages looks fine when the screen is smaller.